### PR TITLE
Update wiki specs for editor roles, rich TOC, and tweet embeds

### DIFF
--- a/docs/vtuber-wiki-spec.md
+++ b/docs/vtuber-wiki-spec.md
@@ -38,48 +38,195 @@
 * `/tags/[tag]` … タグページ
 * `/assets` … 画像ギャラリー
 * `/profile` … プロフィール・通知
-* `/admin/moderation` … モデレーション（curator以上）
+* `/admin/moderation` … モデレーション（adminのみ）
 
 ---
 
 ## 4. 役割 / 権限
 
-| 操作        | viewer | editor(pending) | curator | admin |
-| --------- | ------ | --------------- | ------- | ----- |
-| 閲覧        | ✅      | ✅               | ✅       | ✅     |
-| 新規作成      | ⛔      | ✅（下書き）          | ✅       | ✅     |
-| 編集        | ⛔      | ✅（下書き）          | ✅（即公開可） | ✅     |
-| 公開/ロールバック | ⛔      | ⛔               | ✅       | ✅     |
-| ユーザー凍結    | ⛔      | ⛔               | ⛔       | ✅     |
+| 操作        | viewer | editor | admin |
+| --------- | ------ | ------ | ----- |
+| 閲覧        | ✅      | ✅      | ✅     |
+| 新規作成      | ⛔      | ✅（下書き） | ✅     |
+| 編集        | ⛔      | ✅（下書き + 即公開可） | ✅     |
+| 公開/ロールバック | ⛔      | ✅      | ✅     |
+| ユーザー凍結    | ⛔      | ⛔      | ✅     |
 
-* 新規ユーザー＝`editor(pending)`。下書き送信 → curatorが承認して公開
-* すべての編集は**リビジョン履歴**として保存。ワンクリックでロールバック可能
+* ログインしていない利用者は `viewer`。Discord OAuth でログインし、所定のギルド（サーバー）に参加している場合は自動的に `editor` 権限を付与する。未参加の場合は `viewer` のままとする。
+* `editor` は公開ボタンを保持し、自身または他者のドラフトを即時公開できる。
+* `admin` はユーザー管理・凍結など運営操作も実施可能。
+* すべての編集は**リビジョン履歴**として保存。ワンクリックでロールバック可能。
 
 ---
 
 ## 5. データモデル（要点）
 
 * `users(id, discord_id, name, avatar_url, role)`
-* `pages(id, slug, title, type, created_by, updated_by, is_published)`
+* `pages(id, slug, title, reading, title_image_asset_id, type, created_by, updated_by, is_published)`
 * `page_revisions(id, page_id, editor_id, content_json, summary, created_at)`
 * `tags(id, name)`／`page_tags(page_id, tag_id)`
 * `assets(id, url, uploaded_by, alt, meta)`
 
 > `content_json` は TipTap JSON（構造化ドキュメント）
 
+* `title_image_asset_id` はページタイトル左側に表示する正方形画像を指す。512×512px 以下を推奨し、アップロード時にクライアント側で自動リサイズし、縦横比を 1:1 にクロップする。
+
+### 5.1 TipTap カスタムノード JSON 指針
+
+TipTap のカスタムノードは、`type` にノード名、`attrs` にデータを格納する。`content` があるノードは配下に通常ブロックを保持できる。
+
+#### Infobox (`type: "infobox"`)
+
+```json
+{
+  "type": "infobox",
+  "attrs": {
+    "title": "雪見まりあ",
+    "thumbnail": { "url": "https://...", "alt": "公式立ち絵" },
+    "fields": [
+      { "label": "所属", "value": "個人勢" },
+      { "label": "初配信", "value": "2024-03-01" },
+      { "label": "ファンネーム", "value": "まりあーじゅ" }
+    ],
+    "links": [
+      { "label": "YouTube", "url": "https://youtube.com/@..." },
+      { "label": "X", "url": "https://x.com/..." }
+    ],
+    "colorTheme": "#88E5EF"
+  }
+}
+```
+
+* 必須: `title`
+* 任意: `thumbnail`（`url` 必須、`alt` 任意）、`fields[]`（`label`・`value`必須）、`links[]`（`label`・`url`必須）、`colorTheme`
+* バリデーション: `fields` は最大20件、文字列は 200 文字以内、URL は https のみ許可
+
+#### Timeline (`type: "timeline"`)
+
+```json
+{
+  "type": "timeline",
+  "attrs": {
+    "events": [
+      {
+        "date": "2023-12-24",
+        "title": "デビュー告知",
+        "description": "クリスマスイブに初告知" ,
+        "media": { "url": "https://...", "type": "image" }
+      }
+    ]
+  }
+}
+```
+
+* 必須: `events[]`（各要素に `date` or `dateRange` と `title`）
+* 任意: `description`、`media`（`type`: `image`/`video`, `url`）
+* バリデーション: `events` 最大全体で 100 件、日付は ISO8601 形式、`description` は 500 文字以内
+
+#### Gallery (`type: "gallery"`)
+
+```json
+{
+  "type": "gallery",
+  "attrs": {
+    "layout": "grid",
+    "images": [
+      { "assetId": "asset_123", "url": "https://...", "alt": "1周年記念" }
+    ],
+    "caption": "公式画像まとめ"
+  }
+}
+```
+
+* 必須: `images[]`（`assetId` or `url` のどちらか必須、`alt` 任意）
+* 任意: `layout`（`grid` / `carousel`）、`caption`
+* バリデーション: 画像は最大 12 件、`assetId` がある場合はサーバー側で存在チェック
+
+#### YouTube (`type: "youtube"`)
+
+```json
+{
+  "type": "youtube",
+  "attrs": {
+    "videoId": "dQw4w9WgXcQ",
+    "start": 0,
+    "end": null,
+    "title": "代表的な配信"
+  }
+}
+```
+
+* 必須: `videoId`
+* 任意: `start`（秒数、0 以上の整数）、`end`（`start` より大きい整数 or null）、`title`
+* バリデーション: `videoId` は 11 文字の英数字と `_`、`-`
+
+#### Reference (`type: "reference"`)
+
+```json
+{
+  "type": "reference",
+  "attrs": {
+    "entries": [
+      {
+        "label": "公式サイト",
+        "url": "https://...",
+        "note": "2024-01-01 閲覧"
+      }
+    ]
+  }
+}
+```
+
+* 必須: `entries[]`（`label`・`url`必須）
+* 任意: `note`
+* バリデーション: 1 ページ最大 50 件、URL は https のみ
+
+#### Tweet (`type: "tweet"`)
+
+```json
+{
+  "type": "tweet",
+  "attrs": {
+    "tweetId": "1234567890123456789",
+    "author": "@vtuber",
+    "fallbackText": "告知ツイート",
+    "lang": "ja"
+  }
+}
+```
+
+* 必須: `tweetId`
+* 任意: `author`（表示名 or ハンドル）、`fallbackText`（API 取得失敗時に表示するテキスト）、`lang`
+* バリデーション: `tweetId` は 64bit 整数文字列、`fallbackText` は 280 文字以内。
+* 表示時は Twitter oEmbed を利用し、ダーク/ライトテーマに合わせてテーマパラメータを変更する。埋め込みスクリプト読み込みが失敗した場合は `fallbackText` をカード表示する。
+
+> サーバー保存時は各ノードの `attrs` を zod で検証し、余分なキーは削除する。既存ノードとの互換性のため、未定義のキーは無視して保存しない。
+
 ---
 
 ## 6. API（契約概要）
 
-* `GET /api/pages?query=&type=&tag=&limit=&cursor=` → `{ items, nextCursor }`
+* `GET /api/pages?query=&type=&tag=&limit=&cursor=&sort=` → `{ items, nextCursor }`
 * `GET /api/pages/:slug` → `{ page, latestRevision, publishedRevision }`
 * `POST /api/pages` → `{ id, slug }`（作成）
 * `POST /api/pages/:id/revisions` → `{ revisionId, status }`（要約 `summary` 必須）
-* `POST /api/pages/:id/publish`（curator/admin）
+* `POST /api/pages/:id/publish`（editor/admin）
 * `GET /api/revisions?slug=` → `{ revisions[] }`
 * `POST /api/upload` → `{ uploadUrl, assetId }`（署名URL）
 * `POST /api/report` → `{ ticketId }`
+* 認証フロー: Discord OAuth コールバック時に Bot Token でギルドメンバーシップを検証し、所属していれば `role=editor`、未所属なら `role=viewer` としてセッション/DB を更新する。
 * すべて zod バリデーション + Rate limit + CSRF 対策
+
+### 6.1 RevisionStatus 運用ルール
+
+| 状態          | 生成タイミング                                                | 遷移先                                   |
+| ------------- | ------------------------------------------------------------- | ---------------------------------------- |
+| `DRAFT`       | エディタが `/api/pages/:id/revisions` でリビジョンを作成した時 | `PUBLISHED` / `ROLLED_BACK` |
+| `PUBLISHED`   | editor/admin が `/api/pages/:id/publish` を実行した時         | `ROLLED_BACK`（別リビジョンが公開された時）|
+| `ROLLED_BACK` | `/api/pages/:id/publish` で過去リビジョンに差し替えた時        | なし（履歴参照のみ）                    |
+
+* 公開時は同一ページ内の既存 `PUBLISHED` リビジョンを `ROLLED_BACK` に更新し、`pages.is_published` を `true`、`pages.updated_by` を公開実行者に更新する。
+
 
 ---
 
@@ -131,22 +278,26 @@
 
 ### 8.2 検索（`/search`）
 
-* **フィルタ**: type（character/term/stream/clip/timeline）、tag、sort（recent/popular）
+* **フィルタ**: type（character/term/stream/clip/timeline）、tag、sort（`aiueo` / `created_desc`）
+* **ソート定義**:
+  * `aiueo` … ページタイトルの読み仮名（`pages.reading` フィールド）を五十音順で昇順ソート。読みが未登録の場合はタイトルをそのままかな変換して使用。
+  * `created_desc` … `pages.created_at` の降順。下書き状態のページは含めず、公開済みページのみ対象。
 * **結果**: カード表示（スニペット, タグ, 更新時刻）
 * **ページング**: 無限スクロール
 * **空状態**: 検索Tips
 
 ### 8.3 ページ閲覧（`/wiki/[slug]`）
 
-* **ヘッダ**: タイトル、タグ、編集ボタン（権限）、ブックマーク、通報
+* **ヘッダ**: タイトル、タイトル左の正方形サムネイル（512px 以下）、タグ、編集ボタン（権限）、ブックマーク、通報
 * **情報バー**: 最終更新（ユーザー・日時）、閲覧数、リビジョン数
 * **本文**: TipTap JSON → SSR安全HTML
 
-  * カスタムノード: Infobox / Timeline / Gallery / YouTube / 参考文献
-* **目次（TOC）**: **カテゴリ別折りたたみ**（details/summary）
+  * カスタムノード: Infobox / Timeline / Gallery / YouTube / Tweet / 参考文献
+  * Tweet 埋め込みは oEmbed + lazy load。失敗時は `fallbackText` をカード表示。
+* **目次（TOC）**: **リッチカードレイアウト**（カテゴリ別折りたたみ + アイコン/サムネ）
 
-  * h2/h3 と `data-category` をもとに生成
-  * 現在位置ハイライト（IntersectionObserver）
+  * h2/h3 と `data-category` をもとに生成し、カテゴリごとにガラス質感のカードを横並びレイアウト。各見出しはミニアイコンと読み仮名ラベル付きチップで表示する。
+  * 現在位置ハイライト（IntersectionObserver）に加え、固定サイドパネルとしてスクロール追従し、折りたたみアニメーションに 150ms のフェード/スライドを適用。
 * **右サイド（md+）**: Infobox（アバター、所属、初配信日、ファンネーム、ファンアートタグ、カラー、公式リンク）
 * **フッタ**: 「最終更新の差分を見る」→ `/history/[slug]`、同タグページの横スクロール
 * **404/Wanted Page**: 作成CTA + 参考リンク投稿フォーム
@@ -158,6 +309,7 @@
 
   * 見出し/太字/斜体/リンク/リスト/表/引用/脚注/コード/画像/ギャラリー/タイムライン/区切り線/スラッシュコマンド
   * 画像: D&D → 一時URL → 保存時 Vercel Blob へ確定
+  * タイトルサムネイル: 専用フォームからアップロード/選択。512×512 を上限にクライアントでリサイズし、既存アセットからの選択も可能。
   * オートセーブ（5秒デバウンス） or 手動保存 + 未保存警告
   * 競合: `updatedAt` による楽観ロック
 * **サイドパネル（Infobox）**:


### PR DESCRIPTION
## Summary
- collapse the permission model to viewer/editor/admin with Discord guild checks and clarify revision publishing rules
- document the page title thumbnail workflow and rich table-of-contents experience across viewing and editing flows
- add Tweet embed specifications including TipTap JSON, TypeScript attrs, and renderer fallbacks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3dfdd279c832689d1aeff9e4953b6